### PR TITLE
chore: create GitHub Actions workflow for building binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,68 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+    inputs:
+      name:
+        description: 'Release name'
+        required: true
+        default: 'v0.0.0'
+      is-prerelease:
+        description: 'Is this a pre-release?'
+        required: true
+        type: boolean
+        default: true
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    container: fedora:39
+    permissions:
+      contents: write
+    steps:
+      # Dependencies must be installed before the checkout step, otherwise the
+      # .git directory will be missing and tag creation will fail.
+      - name: Install Dependencies
+        run: |
+          echo "Installing workflow dependencies"
+          dnf install -y git cargo
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Build
+        run: cargo build --release
+
+      - name: Upload to Workflow
+        if: github.event_name != 'workflow_dispatch'
+        uses: actions/upload-artifact@v4
+        with:
+          name: crun-vm
+          path: target/release/
+
+      - name: Create Tag
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          echo "Creating tag"
+          git config --global --add safe.directory /__w/crun-vm/crun-vm
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "github-actions[bot]"
+          git tag -a ${{ github.event.inputs.name }} -m "Release ${{ github.event.inputs.name }} from ${{ github.sha }}"
+          git push origin ${{ github.event.inputs.name }}
+
+      - name: Release
+        if: github.event_name == 'workflow_dispatch'
+        uses: softprops/action-gh-release@v1
+        with:
+          name: ${{ github.event.inputs.name }}
+          tag_name: ${{ github.event.inputs.name }}
+          prerelease: ${{ github.event.inputs.is-prerelease }}
+          files: |
+            target/release/crun-vm
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Closes https://github.com/containers/crun-qemu/issues/5

This provides a much simpler way for individuals to try out the project.  Binaries are built in CI and can simply be downloaded and used, rather than requiring people to install many build dependencies.

Creates a GitHub Actions workflow to do the following:
1. When running in a Pull Request, attaches the binary as a build artifact of the workflow
2. When wanting to publish a semi-stable/beta/whatever release, you can manually invoke the release workflow with the preferred tag name.  This will create a GitHub release with the binary attached.  You can select if this is a pre-release or release version.

All releases and tags will be named as follows:
`<version>-<git-sha>`
But of course, this can be changed further down the line.  I have included the Git SHA to prevent trying to publish to v0.0.0 multiple times, for example.  You can now have v0.0.0-abcdefg(..) and v0.0.0-zyxwvut(..) while you do not wish for this to be considered stable.
