### PR TITLE
first_boot: Add context for genisoimage

### DIFF
--- a/src/commands/create/first_boot.rs
+++ b/src/commands/create/first_boot.rs
@@ -208,8 +208,9 @@ impl FirstBootConfig<'_> {
             .arg(out_config_dir_path.as_ref().join("meta-data"))
             .arg(out_config_dir_path.as_ref().join("user-data"))
             .arg(out_config_dir_path.as_ref().join("vendor-data"))
-            .spawn()?
-            .wait()?;
+            .spawn()
+            .and_then(|mut child| child.wait())
+            .context("Invoking genisoimage")?;
 
         ensure!(status.success(), "genisoimage failed");
 


### PR DESCRIPTION
I got a bare
```
Error: crun-vm: failed to load cloud-init config: No such file or directory (os error 2): OCI runtime attempted to invoke a command that was not found
```

Because my host was missing `genisoimage`.  This turns that into
```
Error: crun-vm: failed to load cloud-init config: Invoking genisoimage: No such file or directory (os error 2): OCI runtime attempted to invoke a command that was not found
```

which is a bit more useful.