### PR TITLE
Don't use `--security-opt label=disable` with Docker

### DIFF
--- a/docs/2-podman-docker.md
+++ b/docs/2-podman-docker.md
@@ -1,11 +1,8 @@
 # 2. Using crun-vm as a Podman or Docker runtime
 
-Here we overview some of the major features provided by crun-vm.
-
-To run the examples below using Docker instead of Podman, you must additionally
-pass `--security-opt label=disable` to docker-run. Other than that, and unless
-otherwise stated, you can simply replace `podman` with `docker` in the commands
-below.
+Here we overview some of the major features provided by crun-vm. The commands
+below use `podman`, but unless otherwise stated you can simply replace it with
+`docker`.
 
 ## Booting VMs
 

--- a/tests/run.rs
+++ b/tests/run.rs
@@ -173,14 +173,9 @@ impl Engine {
 
         if subcommand == "run" {
             match self {
-                Engine::Podman => {
-                    cmd.arg(format!("--runtime={}", BINARY_PATH));
-                }
-                Engine::Docker => {
-                    cmd.arg("--security-opt=label=disable");
-                    cmd.arg("--runtime=crun-vm");
-                }
-            }
+                Engine::Podman => cmd.arg(format!("--runtime={}", BINARY_PATH)),
+                Engine::Docker => cmd.arg("--runtime=crun-vm"),
+            };
         }
 
         cmd.env("RUST_BACKTRACE", "1");


### PR DESCRIPTION
crun-vm now works with Docker without this option on Fedora 39.

Closes #25.