### PR TITLE
chore: add minimal Renovate configuration

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,24 @@
+{
+    /*
+    Configuration Reference:
+    https://docs.renovatebot.com/configuration-options/
+
+    Monitoring Dashboard:
+    https://app.renovatebot.com/dashboard#github/containers
+
+    Configuration Update/Change Procedure:
+        1. Make changes
+        2. Manually validate changes (from repo-root):
+            ```bash
+            $ podman run -it \
+                -v ./.github/renovate.json5:/usr/src/app/renovate.json5:z \
+                ghcr.io/renovatebot/renovate:latest \
+                renovate-config-validator
+            ```
+        3. Commit.
+    */
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "extends": [
+        "github>containers/automation//renovate/defaults.json5"
+    ]
+}


### PR DESCRIPTION
Resolves #22 

Adds the minimal Renovate configuration, inheriting configuration from the org's central config.

Various repositories in this org use different Renovate configs, such as Bootc using the platform-engineering-org's config.  It seemed more logical to use the central configuration from the containers org though, because it seemed more commonly used in Podman etc.  Please let me know if you want it switched over to `"github>platform-engineering-org/.github"`.

I appreciate the project is still very new, so you may not wish to merge this immediately, but it seemed like the only issue I am able to help with, plus it was tagged with "good-first-issue".

Thanks
Rob