### PR TITLE
Add man pages

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,5 +1,27 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+use std::process::Command;
+
 fn main() {
+    // Ensure selinux is linked
     println!("cargo:rustc-link-lib=selinux");
+
+    // Define the input markdown file and the output man page file
+    let input = "docs/src/man/crun-vm.md";
+    let output = "docs/src/man/crun-vm.1";
+
+    // Run the go-md2man command
+    let status = Command::new("go-md2man")
+        .arg("-in")
+        .arg(input)
+        .arg("-out")
+        .arg(output)
+        .status()
+        .expect("Failed to run go-md2man");
+
+    if !status.success() {
+        panic!("go-md2man failed to generate the man page");
+    } else {
+        println!("Generated man page at {}", output);
+    }
 }

--- a/docs/src/man/crun-vm.md
+++ b/docs/src/man/crun-vm.md
@@ -1,0 +1,65 @@
+crun-vm 1 "User Commands"
+==================================================
+
+# NAME
+
+crun-vm - Run VMs as easily as you run containers
+
+# SYNOPSIS
+
+**crun-vm** \[OPTIONS\] \<COMMAND\>
+
+# DESCRIPTION
+
+crun-vm is an OCI Runtime that enables Podman, Docker, and Kubernetes to run QEMU-compatible Virtual Machine (VM) images.
+
+# COMMANDS
+
+  create      Create a container
+
+  start       Start a previously created container
+
+  state       Show the container state
+
+  kill        Send the specified signal to the container
+
+  delete      Release any resources held by the container
+
+  checkpoint  Checkpoint a running container
+
+  events      Show resource statistics for the container
+
+  exec        Execute a process within an existing container
+
+  features    Return the features list for a container
+
+  list        List created containers
+
+  pause       Suspend the processes within the container
+
+  ps          Display the processes inside the container
+
+  resume      Resume the processes within the container
+
+  run         Create a container and immediately start it
+
+  update      Update running container resource constraints
+
+  spec        Command generates a config.json
+
+  help        Print this message or the help of the given subcommand(s)
+
+# OPTIONS
+
+  -l, --log \<LOG\>                set the log file to write youki logs to (default is '/dev/stderr')
+
+        --debug                    change log level to debug, but the `log-level` flag takes precedence
+
+        --log-format <LOG_FORMAT>  set the log format ('text' (default), or 'json') (default: "text")
+
+  -r, --root \<ROOT\>              root directory to store container state
+
+  -s, --systemd-cgroup           Enable systemd cgroup manager, rather then use the cgroupfs directly
+
+  -h, --help                     Print help
+

--- a/plans/tests.fmf
+++ b/plans/tests.fmf
@@ -13,6 +13,7 @@ prepare:
       - crun
       - docker
       - genisoimage
+      - golang-github-cpuguy83-md2man
       - grep
       - guestfs-tools
       - libselinux-devel

--- a/tests/env.sh
+++ b/tests/env.sh
@@ -182,6 +182,7 @@ build)
         docker \
         genisoimage \
         grep \
+        golang-github-cpuguy83-md2man \
         htop \
         libselinux-devel \
         libvirt-client \


### PR DESCRIPTION
The build script now includes a step to convert the markdown documentation into a man page using the go-md2man tool.

Add a new man page for crun-vm.